### PR TITLE
fix: 'deque' does not name a type

### DIFF
--- a/Software/ROS2/controller/include/Hlip/S2S_controller.hpp
+++ b/Software/ROS2/controller/include/Hlip/S2S_controller.hpp
@@ -44,6 +44,7 @@
 #include "Eigen/Dense"
 #include "output_controller.hpp"
 #include "moving_average_filter.hpp"
+#include <deque>
 
 using namespace rclcpp;
 using namespace std::chrono_literals;

--- a/Software/ROS2/controller/src/S2S_controller.cpp
+++ b/Software/ROS2/controller/src/S2S_controller.cpp
@@ -481,7 +481,7 @@ namespace hardware_ns
             stance_leg contact_foot=left_leg;
             stance_leg previous_contact = right_leg; //1 for left_foot, 2 for right
             double pitch=0;
-            deque<double> pitch_list;
+            std::deque<double> pitch_list;
             double pitch_vel = 0;
             bool released=false;
             double time_now;


### PR DESCRIPTION
**Error**

```text
/workspace/ros2_ws/src/STRIDE/Software/ROS2/controller/src/S2S_controller.cpp:484:13: error: ‘deque’ does not name a type
484 |             deque<double> pitch_list;
    |             ^~~~~
```

**Solution**

Used std::deque instead of deque in [S2S_controller.cpp](https://github.com/well-robotics/STRIDE/blob/main/Software/ROS2/controller/src/S2S_controller.cpp#L484) and added below line in [S2S_controller.hpp](https://github.com/well-robotics/STRIDE/blob/main/Software/ROS2/controller/include/Hlip/S2S_controller.hpp#L47).

```cpp
#include <deque>
```

**System**

osrf/ros:humble-desktop-full docker image (Ubuntu 22.04, ROS 2 Humble) on arch linux.

**Dockerfile**
```Dockerfile
FROM osrf/ros:humble-desktop-full

WORKDIR /workspace

ENV ROS_DISTRO=humble
ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/workspace/ros2_ws/install/mujoco/lib/mujoco/lib

RUN apt-get update && apt-get install vim libglfw3-dev libserial-dev -y

RUN cd /tmp && git clone https://github.com/WiringPi/WiringPi.git && cd WiringPi && ./build

CMD ["bash"]
```
